### PR TITLE
Changed referenceBlock to define block

### DIFF
--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -4,7 +4,7 @@
         <css src="Elgentos_CategorySidebar::css/module.css" />
     </head>
     <body>
-        <referenceBlock name="category-sidebar" template="Elgentos_CategorySidebar::category-sidebar-search.phtml" />
+        <block class="Elgentos\CategorySidebar\Block\CategorySidebar" name="category-sidebar" template="Elgentos_CategorySidebar::category-sidebar-search.phtml" />
         <move element="category-sidebar" destination="sidebar.main" before="catalogsearch.leftnav" />
     </body>
 </page>


### PR DESCRIPTION
The problem here was that this categories sidebar would never show on the search page because category-sidebar is never defined in the search XML. This could either work by accident (Meaning somewhere in another XML a block with this name was made) or just not work at all i.e not showing.

By defining the class and making it a block instead of a referenceBlock fixes that issue so it works.